### PR TITLE
Fixed Parsing for double values in different locations

### DIFF
--- a/Gcodes/Parser.cs
+++ b/Gcodes/Parser.cs
@@ -162,7 +162,7 @@ namespace Gcodes
             var valueTok = Chomp(TokenKind.Number) ?? throw ParseError(TokenKind.Number);
 
             var span = kindTok.Span.Merge(valueTok.Span);
-            var value = double.Parse(valueTok.Value);
+            var value = double.Parse(valueTok.Value, CultureInfo.InvariantCulture);
             var kind = kindTok.Kind.AsArgumentKind();
 
             return new Argument(kind, value, span);


### PR DESCRIPTION
on a German computer two tests break because in double values "," is used instead of ".". This fix should make double parsing independent of location settings